### PR TITLE
Fixing django_seo_js middleware

### DIFF
--- a/csp/settings.py
+++ b/csp/settings.py
@@ -75,15 +75,16 @@ INSTALLED_APPS = [
 
 ]
 MIDDLEWARE_CLASSES = [
+    'django_seo_js.middleware.EscapedFragmentMiddleware',  # If you're using #!
+    'django_seo_js.middleware.UserAgentMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     # 'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django_seo_js.middleware.EscapedFragmentMiddleware',  # If you're using #!
-    'django_seo_js.middleware.UserAgentMiddleware'
+
 ]
-SEO_JS_PRERENDER_TOKEN = "123456789abcdefghijkl"
+
 ROOT_URLCONF = 'csp.urls'
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
@@ -121,6 +122,14 @@ DATABASES = {
 
     }
 }
+
+SEO_JS_ENABLED = True
+# -----Uncomment below for local prerender server
+# SEO_JS_BACKEND = "django_seo_js.backends.PrerenderHosted"
+# SEO_JS_PRERENDER_URL = "http://localhost:3000/"  # Note trailing slash.
+# SEO_JS_PRERENDER_RECACHE_URL = "http://localhost:3000/recache"
+#
+# SEO_JS_PRERENDER_TOKEN = "123456789abcdefghijkl"
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/

--- a/static/templates/base/index.html
+++ b/static/templates/base/index.html
@@ -1,15 +1,17 @@
 {% load staticfiles %}
 {% load compress %}
-{% load django_seo_js %}
-{% seo_js_head %}
+
 <html lang="en" ng-app="crowdsource">
+{% load django_seo_js %}
+
 <head>
+  {% seo_js_head %}
     <base href="/">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="author" content="neilg, dmorina">
-
+    <meta name="fragment" content="!">
     <title>daemo</title>
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@CrowdVoyant"/>


### PR DESCRIPTION
Settings fix in django_seo_js middleware

For twitter use :` <link> + '?_escaped_fragment_='` to show updated meta tags.